### PR TITLE
fix: Changed correct render route in map controller(getMap)  to mapView.ejs

### DIFF
--- a/controllers/map.js
+++ b/controllers/map.js
@@ -1,0 +1,6 @@
+module.exports = {
+    getMap: (req, res) => {
+      res.render("mapView.ejs"); // TODO: change to right view
+    },
+  };
+  

--- a/controllers/map.js
+++ b/controllers/map.js
@@ -3,4 +3,3 @@ module.exports = {
       res.render("mapView.ejs"); // TODO: change to right view
     },
   };
-  


### PR DESCRIPTION



Title:  Changed correct render route in map controller(getMap)  to mapView.ejs

Related Issue(s):
- Closes #24



Branch: `24-map-view-route`

What’s Included
Changed the res.render route in mapController

Notes for Reviewers
N/A
