### PR TITLE
fix(controller):fix routes

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,5 +1,5 @@
 module.exports = {
-  getLanding: (req, res) => {
+  getIndex: (req, res) => {
     res.status(200).render("landing.ejs");
   },
 };


### PR DESCRIPTION
Title: This pull request resolves a testing error originating from main.js due to a function name mismatch within the homeController. Previously, main.js attempted to call getIndex, but the controller was exporting getLanding. This fix updates the controller to ensure consistency, allowing getIndex to be correctly recognized and invoked during testing.

Related Issue(s):
- Closes: 48 Update landing controller
- Related to #21 Landing

Branch: 21-landing-route

What’s Included
This PR addresses a function name mismatch that caused an error in main.js during testing. Previously, main.js was trying to call a function named getIndex, but our homeController was exporting a function named getLanding. This fix updates the controller to correctly export getIndex, resolving the inconsistency and allowing the application to function as intended

Notes for Reviewers

