### PR TITLE
feat(posts-schema): Added Post related Schema and functions

### DIFF
--- a/models/Post.js
+++ b/models/Post.js
@@ -13,7 +13,7 @@ const PostSchema = new mongoose.Schema({
     type: String,
     require: true,
   },
-  caption: {
+  description: {
     type: String,
     required: true,
   },
@@ -21,7 +21,7 @@ const PostSchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
-  user: {
+  postedBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "User",
   },
@@ -29,6 +29,54 @@ const PostSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  address: String,
+  latitude: String,
+  longitude: String,
+  time: Date,
+  city: String,
+  isResolved: Boolean,
+  isHidden: Boolean,
+  isAnonymous: Boolean,
+  isVerified: Boolean,
+  type: AlertSchema,
+  upvotes: {
+    type: Number,
+    default: 0,
+  },
+  downvotes: {
+    type: Number,
+    default: 0,
+  }
 });
 
-module.exports = mongoose.model("Post", PostSchema);
+PostSchema.methods.generateUserHash = function (userId) {
+  return userId + String(this._id);
+}
+
+const UserPostSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User"
+  },
+  post: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Post"
+  },
+  _id: {
+    type: String,
+    unique: true,
+    required: true,
+  },
+})
+
+const PostUserDownvotesSchema = new mongoose.Schema(UserPostSchema);
+
+const PostUserUpvotesSchema = new mongoose.Schema(UserPostSchema);
+
+
+module.exports = {
+  Post: mongoose.model("Post", PostSchema),
+  PostUserDownvoteSchema: mongoose.model("PostUserDownvote", PostUserDownvotesSchema),
+  PostUserUpvoteSchema: mongoose.model("PostUserUpvote", PostUserUpvotesSchema),
+  UserPostSchema,
+};

--- a/models/Post.js
+++ b/models/Post.js
@@ -7,19 +7,12 @@ const PostSchema = new mongoose.Schema({
   },
   image: {
     type: String,
-    require: true,
   },
   cloudinaryId: {
     type: String,
-    require: true,
   },
   description: {
     type: String,
-    required: true,
-  },
-  likes: {
-    type: Number,
-    required: true,
   },
   postedBy: {
     type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
# **Title:** Post Schemas: Added Post related Schema and function

## **Related Issue(s):**
- Closes #27 
- Related to #40 #33 #25 

#### **Branch:** `27-post-schema`

### What’s Included

| Object | Notes | 
| ------ | ------ |
| Post | A post will become a pin on the map, a title will be required, and users should be logged in to use this |
| UserPostSchema | Defines a relationship between the user and the post, used in `upvoting`, `downvoting` and `bookmarks` |
| PostUserUpvoteSchema | Stores Upvotes |
| PostUserDownvoteSchema | Stores Downvotes |
| PostSchema.methods.generateUserHash | Takes one argument `userId`. Creates a unique string to store the user-post relationship. Used in Post upvotes, downvotes and `maybe bookmarks`

