### PR TITLE
feat: added signup page content layout

### DIFF
--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -12,26 +12,34 @@
                         <div class="alert alert-info"><%= el.msg %></div>
                     <% }) %>    
                 <% } %>
+                <section>
+                  <h2>Sign Up to Create Alerts</h2>
+                  <span>Welcome!</span>
+                </section> 
                 <form action="/signup" method="POST">
                     <div class="mb-3">
-                        <label for="userName" class="form-label">User Name</label>
-                        <input type="text" class="form-control" id="userName" name="userName">
-                      </div>
+                      <label for="email" class="form-label">Email address</label>
+                      <input type="email" class="form-control" id="email" aria-describedby="emailHelp" name="email" required>
+                    </div>
                     <div class="mb-3">
-                      <label for="exampleInputEmail1" class="form-label">Email address</label>
-                      <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" name="email">
-                      <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div>
+                        <label for="firstName" class="form-label">First Name</label>
+                        <input type="text" class="form-control" id="firstName" name="firstName" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="lastName" class="form-label">Last Name</label>
+                        <input type="text" class="form-control" id="lastName" name="lastName" required>
                     </div>
                     <div class="mb-3">
                       <label for="password" class="form-label">Password</label>
-                      <input type="password" class="form-control" id="password" name="password">
+                      <input type="password" class="form-control" id="password" name="password" required>
                     </div>
                     <div class="mb-3">
-                        <label for="confirmPassword" class="form-label">Confirm Password</label>
-                        <input type="password" class="form-control" id="confirmPassword" name="confirmPassword">
-                      </div>
-                    <button type="submit" class="btn btn-primary">Submit</button>
+                      <label for="zipCode" class="form-label">Zip Code</label>
+                      <input type="text" class="form-control" pattern="[0-9]{5}" title="Please enter a 5-digit zip code" id="zipCode" name="zipCode" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Sign Up</button>
                   </form>
+                  <p>Already have an account? <a>Sign in.</a></p>
             </section>
         </div>
     </main>


### PR DESCRIPTION
Related Issue(s):
- Closes #36
- Related to #36[sign up page content]

Branch: 36-sign-up-page

What’s Included
- Added content structure for signup page
- Includes basic form layout, text fields, and call-to-action message
- No logic or styling included yet

Notes for Reviewers
- Replit logic will be added after logic tickets are released
- File renamed correctly to signup.ejs and matches assigned task