### PR TITLE
 Feature(Posts): Added logic for getting feed and creating posts

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -41,7 +41,10 @@ module.exports = {
       return redirect('/map');
     };
     try {
-      const postData = { ...req.body };
+      const postData = { 
+        ...req.body,
+        postedBy: req.user.id
+      };
       let result = null;
       if (req.file) {
         result = await cloudinary.uploader.upload(req.file.path, { asset_folder: 'safeRouteImages', public_id_prefix: 'post'  });


### PR DESCRIPTION
# **Title:** Feature(Posts): Added logic for getting feed and creating posts

## **Related Issue(s):**
- Closes #53 
- Related to #40 #33 #27 #59 

#### **Branch:** `53-build-controller`

### What’s Included

| Controller | Notes | 
| ---------- | ------ |
| getFeed | Gets all posts that are not hidden or resolved (Ignore if not used). Also adds a filter on type (String)  |
| createPost | Creates a new post object. We expect the data to be `complete` from the frontend |


### Notes for Reviewers
For `@DevOps `and `@Frontend`, These routes can now be used on the frontend:
- [x] `/feed` -> Renders the feed.ejs, returns `posts`, `user` for your use in feed.ejs
- [x] `/post/createPost` -> Creates a post and redirects to `/map` when done. 

