### PR TITLE
fix: Updated bookmark post route to put instead of delete + added middleware to all user feature routes

### DIFF
--- a/routes/posts.js
+++ b/routes/posts.js
@@ -5,17 +5,16 @@ const postsController = require("../controllers/posts");
 const { ensureAuth, ensureGuest } = require("../middleware/auth");
 
 //Post Routes - simplified for now
-router.get("/:id", ensureAuth, postsController.getPost);
+router.get("/:id", postsController.getPost);
 
-router.post("/newPost", upload.single("file"), postsController.createPost);
+router.post("/newPost", ensureAuth, upload.single("file"), postsController.createPost);
 
 router.put("/:id/upvote", ensureAuth, postsController.upvotePost);
 
 router.put("/:id/downvote", ensureAuth, postsController.downvotePost);
 
-router.delete("/:id/bookmark", postsController.bookmarkPost);
+router.put("/:id/bookmark", ensureAuth, postsController.bookmarkPost);
 
-router.delete("/:id/deletePost", postsController.deletePost);
-
+router.delete("/:id/deletePost", ensureAuth, postsController.deletePost);
 
 module.exports = router;


### PR DESCRIPTION
Title: fix: Updated bookmark post route to put instead of delete + added middleware to all user feature routes

**Related Issue(s):**
- Closes #69 
- Related to #67 

Branch: 69-fix-bookmark-route

What’s Included
Updated bookmark post route to put instead of delete + added middleware to all user feature routes

Notes for Reviewers
Switched the bookmark route for toggling bookmarks from "delete" to "put". Also added middleware to all routes other than "get" to see the posts loaded on the page.