### PR TITLE
feat(Pin and UnPin):Added Pin/Unpin Logic for User Posts

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -1,6 +1,7 @@
 const cloudinary = require("../middleware/cloudinary");
 const Post = require("../models/Post");
 const Comment = require("../models/Comment");
+const Pin = require("../models/Pin");
 
 module.exports = {
   getProfile: async (req, res) => {
@@ -21,7 +22,8 @@ module.exports = {
   },
   getPost: async (req, res) => {
     try {
-      const post = await Post.findById(req.params.id);
+      // Find the post (Change the id to postID)
+      const post = await Post.findById(req.params.postID);
       const comments = await Comment.find({ post: req.params.id }).sort({ createdAt: -1 }).lean();
       res.render("postView.ejs", { post: post, user: req.user, comments: comments });
     } catch (err) {
@@ -76,4 +78,43 @@ module.exports = {
       res.redirect("/profile");
     }
   },
+// Pending post pin 
+
+  // The pin/un pin
+  userPostPin: async (req, res) => {
+    // Extract post and user IDs from request parameters
+    const { postID, userID } = req.params;
+
+    try {
+      // Check if a pin for this user and post already exists
+      let existingPin = await db.collection('pins').findOne({
+        user_id: userID,
+        post_id: postID
+      });
+
+      // If a pin exists, delete it (toggling the pin off)
+      if (existingPin) {
+        // Assuming 'Pin' is a Mongoose model, use findOneAndDelete for clarity
+        await Pin.findOneAndDelete({
+          user_id: userID,
+          post_id: postID
+        });
+        console.log('Pin successfully deleted.');
+
+      } else {
+        // If no pin exists, create a new one (toggling the pin on)
+        let newPin = new Pin({
+          user: userID,
+          post: postID
+        });
+
+        let savedPin = await newPin.save();
+        console.log('New pin saved:', savedPin);
+      }
+
+    } catch (err) {
+      console.error('Error updating pin status:', err);
+      res.redirect('/profile'); // Redirect on error
+    }
+  }
 };


### PR DESCRIPTION
Title: Implement Pin/Unpin for User Content Management

**Related Issue(s):**
- Closes #54 

Branch: 54-add-pinunpin-logic

What’s Included
This PR introduces an API endpoint for toggling the pin status of user posts. It allows users to either pin a post (by creating a new pin entry) or unpin a post (by deleting an existing pin entry) within the database.

Notes for Reviewers
Still missing the route for the pin unpost. Created an example: router.put('/pin/:postID/:userID', postsController.userPostPin);. Also, need a bookmark/pin schema!