### PR TITLE
Feat(map-view): Serve posts and user objects on map view render

### DIFF
--- a/controllers/map.js
+++ b/controllers/map.js
@@ -1,5 +1,16 @@
+const { Post } = require('../models/Post');
+
 module.exports = {
-    getMap: (req, res) => {
-      res.render("mapView.ejs"); // TODO: change to right view
-    },
-  };
+  getMap: (req, res) => {
+    try {
+      const posts = Post.find({
+        isHidden: false,
+        isResolved: false,
+      }).lean();
+      res.render("mapView.ejs", { user: req.user, posts });
+    } catch (err) {
+      console.log('Unable to fetch posts', err);
+      res.redirect('/');
+    }
+  },
+};


### PR DESCRIPTION
**Title:** MapView - Serve posts and user objects on map view render

**Related Issue(s):**
- Closes #83 
- Related to #24 #60 #32 

**Branch:** `83-add-post-data-logic`

What’s Included
- Sent the posts (An array of all `Post` objects - which aren't not hidden or resolved)
- Redirect to `/` on error

Notes for Reviewers
`posts` will return an empty array if there aren't any, this just means no pins on the map. There is some seed data in the DB so let us know if there are any errors on render.
