### PR TITLE
fix: updated Alerts nav links in header and footer to route to /feed

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -12,7 +12,7 @@
   <div class="footer-links">
     <a href="/">Home</a>
     <a href="/map">Map</a>
-    <a href="/alerts">Alerts</a>
+    <a href="/feed">Alerts</a>
     <a href="/resources">Resources</a>
   </div>
 </footer>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -20,7 +20,7 @@
   <nav class="nav-menu">
     <a href="/" class="<%= typeof currentPage !== 'undefined' && currentPage === 'home' ? 'active' : '' %>">Home</a>
     <a href="/map" class="<%= typeof currentPage !== 'undefined' && currentPage === 'map' ? 'active' : '' %>">Map</a>
-    <a href="/alert" class="<%= typeof currentPage !== 'undefined' && currentPage === 'alert' ? 'active' : '' %>">Alert</a>
+    <a href="/feed" class="<%= typeof currentPage !== 'undefined' && currentPage === 'alert' ? 'active' : '' %>">Alerts</a>
     <a href="/resources" class="<%= typeof currentPage !== 'undefined' && currentPage === 'resources' ? 'active' : '' %>">Resources</a>
 
     <% if (typeof user !== 'undefined' && user) { %>  


### PR DESCRIPTION
Related Issue(s):
Closes #109 
Related to #80 

Branch: 109-navigation-bar-fix

What’s Included:

- Updated the Alerts <a> link in header.ejs to route to /feed

- Also updated the Alerts link in footer.ejs to match

- Verified both links render and route correctly on local server


Notes for Reviewers:

- Both links are visible to all users (logged in or out)

- This fix is front-end only and does not affect backend logic

- No breaking changes expected — please confirm routing consistency across pages