### PR TITLE
fix: Added auth middleware to all comment routes

### DIFF
--- a/routes/comments.js
+++ b/routes/comments.js
@@ -3,13 +3,17 @@ const router = express.Router();
 const commentsController = require("../controllers/comments");
 const { ensureAuth, ensureGuest } = require("../middleware/auth");
 
- console.log('we made it to routes')
+console.log('we made it to routes')
 
 //Post Routes - simplified for now
+<<<<<<< Updated upstream
 router.post("/createComment/:id", commentsController.createComment);
+=======
+router.post("/createComment/:id", ensureAuth, commentsController.createComment);
+>>>>>>> Stashed changes
 
-router.put("/likeComment/:id", commentsController.likeComment);
+router.put("/likeComment/:id", ensureAuth, commentsController.likeComment);
 
-router.delete("/deleteComment/:id", commentsController.deleteComment);
+router.delete("/deleteComment/:id", ensureAuth, commentsController.deleteComment);
 
 module.exports = router;


### PR DESCRIPTION
Title: fix: Added auth middleware to all comment routes

Related Issue(s):
- Closes #114
- Related to #57

Branch: 114-add-middleware

What’s Included
Added ensureAuth middleware to all comment routes

Notes for Reviewers
Ticket is slightly related to #57 as it alters the methods by giving them a requirement for the user to be signed in.