### PR TITLE
feat(Hidden Comments And Post): Add hidden status for posts and comment

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -49,14 +49,15 @@ module.exports = {
   },
   deleteComment: async (req, res) => {
     try {
-      const deleteComment = await Comment.findByIdAndDelete(req.params.id );
+      const deleteComment = await Comment.findByIdAndUpdate(req.params.id, 
+        {isHidden: true});
 
       if (!deleteComment) {
         console.log("Comment not found for deletion:", req.params.id);
         return res.redirect('back');
       }
 
-      console.log("Deleted Comment");
+      console.log("Hidden Comment");
       res.redirect("back");
     } catch (err) {
       res.status(500).json({message: "Delelation was not succesful", error: err.message})

--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -42,7 +42,7 @@ module.exports = {
       if (!post) {
       res.status(404).send('Sorry, the page you are looking for does not exist.');
     }
-    const comments = await Comment.find({ post: req.params.id }).sort({ createdAt: -1 }).lean();
+    const comments = await Comment.find({ post: req.params.id , isHidden: false }).sort({ createdAt: -1 }).lean();
       res.render("post.ejs", {
       Title: "SafeRoute | Post",
       currentPage: "post",
@@ -188,7 +188,10 @@ module.exports = {
       await Bookmark.deleteMany({ post: req.params.id });
 
       // Delete the post 
-      await Post.findByIdAndDelete({ _id: req.params.id });
+      await Post.findByIdAndUpdate({ _id: req.params.id, isHidden: true});
+
+      // 'Delete' the comments
+      await Comment.findByIdAndUpdate({_id: req.params.id, isHidden:true})
 
       console.log("Success! Your post has been deleted.");
       res.redirect("/feed");

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -16,7 +16,11 @@ const CommentSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: "User"
   }],
-  
+  // Hidden
+    isHidden: {
+    type: Boolean,
+    default: false
+  },
   user: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "User",


### PR DESCRIPTION
Title: feat: Add hidden status for posts and comments

Related Issue(s):
- Closes #115 


Branch: 115-hide-commentsposts-functionality

What’s Included

his PR introduces a new hidden content functionality allowing administrators or content owners to mark posts and comments as hidden. It adds an isHidden boolean field (defaulting to false) to both the Post and Comment Mongoose schemas. The change modifies existing content retrieval routes to filter out hidden items by default for public consumption, while also introducing new API endpoints to toggle the isHidden status, enabling content moderation. This feature improves content management capabilities without fixing a specific bug.

Notes for Reviewers
None
