### PR TITLE
fix: moved feed.css to top of feed.ejs for scoped styling

### DIFF
--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -1,4 +1,6 @@
 <%- include('partials/header') -%>
+<link rel="stylesheet" href="/css/feed.css" />
+
   <div class="container">
     <h1 class="center navy-blue">Post Sightings</h1>
     <h2 class="center navy-blue">View real-time incidents to help vulnerable communities</h2>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -6,9 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SafeRoute</title>
 
-    <!-- External Stylesheets -->
+    <!-- External Stylesheets - DO NOT ADD MORE - ADD ALL FUTURE STYLESHEETS ON TOP LINE OF YOUR EJS FILE -->
     <link rel="stylesheet" href="/css/style.css" />
-    <link rel="stylesheet" href="/css/feed.css" />
     <link rel="stylesheet" href="/css/headerFooter.css" />
    
   </head>


### PR DESCRIPTION
**Related Issue(s):**
Closes #119 
Branch: 119-page-specific-stylesheets

**What’s Included:**

- Removed global feed.css link from header.ejs
- Added page-specific <link> to feed.ejs to isolate styles
- This ensures feed.css only affects the feed page and avoids styling conflicts on other views

**Notes for Reviewers:**

- Other pages (e.g., resources.ejs, mapView.ejs) already include their own styles via separate tickets
- Angie and Marie will include their stylesheets in their own styling tickets
- This is part of our fix to reduce stylesheet overlap and improve page-specific design control