### PR TITLE
feat: Updated User schema to support geospatial queries and geocoder logic

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,5 +1,6 @@
 const passport = require("passport");
 const validator = require("validator");
+const NodeGeocoder = require('node-geocoder');
 const { User } = require("../models/User");
 
 exports.getSigninPage = (req, res) => {
@@ -69,7 +70,7 @@ exports.getSignupPage = (req, res) => {
   });
 };
 
-exports.postSignup = (req, res, next) => {
+exports.postSignup = async (req, res, next) => {
   const validationErrors = [];
   if (!validator.isEmail(req.body.email))
     validationErrors.push({ msg: "Please enter a valid email address." });
@@ -92,34 +93,46 @@ exports.postSignup = (req, res, next) => {
     gmail_remove_dots: false,
   });
 
-  const user = new User({
-    firstName: req.body.firstName,
-    lastName: req.body.lastName,
-    email: req.body.email,
-    password: req.body.password,
-  });
-
-  User.findOne(
-    { email: req.body.email }
-  ).then(existingUser => {
+ try {
+  const existingUser = await  User.findOne(
+    { email: req.body.email });
     if (existingUser) {
       req.flash("errors", {
         msg: "Account with that email address already exists.",
       });
       return res.redirect("../signup");
     }
-    user.save()
-      .then(newUser => {
+
+    const geocoder = NodeGeocoder({ provider: 'openstreetmap' });
+    const geoResults = await geocoder.geocode({ zipcode: req.body.zipCode, countryCode: 'US' });
+
+    let coordinates = undefined;
+    if (geoResults && geoResults.length > 0) {
+      const { latitude, longitude } = geoResults[0];
+      coordinates = [longitude, latitude];
+    }
+
+    const user = new User({
+      firstName: req.body.firstName,
+      lastName: req.body.lastName,
+      email: req.body.email,
+      password: req.body.password,
+      zipCode: req.body.zipCode,
+      location: coordinates
+        ? { type: 'Point',
+          coordinates }
+        : undefined,
+    });
+
+     await user.save();
+
         req.logIn(newUser, (err) => {
-          res.redirect("/map");
-        });
-      }).catch((err) => {
-        if (err) {
-          return next(err);
-        }
-      });
-  }
-  ).catch((err) => {
+      if (err) return next(err);
+      res.redirect("/map");
+    });
+
+  } catch (err) {
     return next(err);
-  })
+  }
 };
+ 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -104,13 +104,14 @@ exports.postSignup = async (req, res, next) => {
     }
 
     const geocoder = NodeGeocoder({ provider: 'openstreetmap' });
-    const geoResults = await geocoder.geocode({ zipcode: req.body.zipCode, countryCode: 'US' });
-
+    const geoResults = await geocoder.geocode({ postalcode: req.body.zipCode, country: 'US' });
+  
     let coordinates = undefined;
     if (geoResults && geoResults.length > 0) {
       const { latitude, longitude } = geoResults[0];
       coordinates = [longitude, latitude];
-    }
+    } 
+    
 
     const user = new User({
       firstName: req.body.firstName,
@@ -126,7 +127,7 @@ exports.postSignup = async (req, res, next) => {
 
      await user.save();
 
-        req.logIn(newUser, (err) => {
+        req.logIn(user, (err) => {
       if (err) return next(err);
       res.redirect("/map");
     });

--- a/models/User.js
+++ b/models/User.js
@@ -7,9 +7,21 @@ const UserSchema = new mongoose.Schema({
   email: { type: String, unique: true },
   password: String,
   zipCode: String,
-  longitude: String,
-  latitude: String,
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'],
+      required: true
+    },
+    coordinates: {
+      type: [Number],
+      required: true
+    }
+  },
 });
+
+UserSchema.index({ location: '2dsphere' });
+
 
 // Password hash middleware.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.14.1",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
+    "node-geocoder": "^4.4.1",
     "nodemon": "^3.1.10",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
Title: Updated User schema to support geospatial queries and geocoder logic

Related Issue(s):
- Closes #151 


Branch: `151-add-geolocation-schema`

What’s Included:
Updated the user schema to now uses geoJSON format along with setting it up to support geospatial queries. Added a package for "node-geocoder". Now the geocoding is handled by a nodejs library. Cool! Added logic to ensure location data is saved on signup. Added default handling for empty coordinates. Removed redundancy of lat, lng in user schema.

Notes for Reviewers:
After merge, announcement needs to be mad to run npm install after git pull as package.json has been updated.
