### PR TITLE
feat: #178 integrated toastifyjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "nodemon": "^3.1.10",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
+        "toastify-js": "^1.12.0",
         "validator": "^13.6.0"
       }
     },
@@ -2470,6 +2471,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toastify-js": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
+      "integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4311,6 +4318,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toastify-js": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
+      "integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ=="
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nodemon": "^3.1.10",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
+    "toastify-js": "^1.12.0",
     "validator": "^13.6.0"
   }
 }

--- a/public/js/toast.js
+++ b/public/js/toast.js
@@ -1,0 +1,27 @@
+function showToast(message, type = "success") {
+  Toastify({
+    text: message,
+    duration: 4000,
+    gravity: "top",
+    position: "right",
+    style: {
+      background: type === "error"
+        ? "linear-gradient(to right, #e53935, #e35d5b)"
+        : "linear-gradient(to right, #00b09b, #96c93d)"
+    }
+  }).showToast();
+}
+
+// Make globally accessible
+window.showToast = showToast;
+
+// When page is done loading, this lets us autoread toastMessage/toastType from our URLs if we need
+document.addEventListener("DOMContentLoaded", function() {
+  var params = new URLSearchParams(window.location.search);
+  var message = params.get("toastMessage");
+  var type    = params.get("toastType");
+
+  if (message) {
+    showToast(message, type);
+  }
+});

--- a/public/js/toast.js
+++ b/public/js/toast.js
@@ -23,5 +23,17 @@ document.addEventListener("DOMContentLoaded", function() {
 
   if (message) {
     showToast(message, type);
-  }
+  } 
+
+// Applies to any forms, If any HTML5 validation fails, stops ugly native bubble and show pretty toast msg instead
+  const allForms = document.querySelectorAll("form");
+  allForms.forEach(form => {
+    form.addEventListener("submit", function(evt) {
+      if (!form.checkValidity()) {
+        evt.preventDefault();
+        const firstInvalid = form.querySelector(":invalid");
+        showToast(firstInvalid.validationMessage, "error");
+      }
+    });
+  });
 });

--- a/public/mapView(main).js
+++ b/public/mapView(main).js
@@ -172,7 +172,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Validate required fields
         if (!formData.incidentType || !formData.address) {
-            alert('Please fill in all required fields (Incident Type and Address).');
+            showToast('Please fill in all required fields (Incident Type and Address).', 'error');
             return;
         }
 
@@ -192,7 +192,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 // Validate that result is within U.S. bounds
                 if (!isWithinUSBounds(lat, lng)) {
-                    alert('Please enter a valid U.S. address. International locations are not supported.');
+                    showToast('Please enter a valid U.S. address. International locations are not supported.', "error");
                     return;
                 }
 
@@ -260,7 +260,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 })
                 .then(data => {
                     console.log('Alert stored successfully:', data);
-                    alert('Alert submitted successfully and marker added to map!');
+                    showToast('Alert submitted successfully and marker added to map!');
                     
                     // Reset form
                     document.getElementById('alertForm').reset();
@@ -274,11 +274,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
 
             } else {
-                alert('Could not find the specified address. Please check the address and try again.');
+                showToast('Could not find the specified address. Please check the address and try again.', 'error');
             }
         }, function(error) {
             console.error('Geocoding error:', error);
-            alert('Error finding address location. Please try again.');
+            showToast('Error finding address location. Please try again.', 'error');
         });
     });
 
@@ -308,7 +308,7 @@ function searchAlerts() {
     const location = document.getElementById('searchLocation').value.trim();
 
     if (!location) {
-        alert('Please enter an address or zip code.');
+        showToast('Please enter an address or zip code.', 'error');
         return;
     }
 
@@ -338,7 +338,7 @@ function performGeocode(query, originalInput) {
             const lng = result.center.lng;
 
             if (!isWithinUSBounds(lat, lng)) {
-                alert('Please enter a valid U.S. address or zip code. International locations are not supported.');
+                showToast('Please enter a valid U.S. address or zip code. International locations are not supported.', "error");
                 return;
             }
 
@@ -361,13 +361,13 @@ function performGeocode(query, originalInput) {
 
         } else {
             if (isValidUSZipCode(originalInput)) {
-                alert('Zip code not found. Please check the zip code and try again.');
+                showToast('Zip code not found. Please check the zip code and try again.', 'error');
             } else {
-                alert('Location not found. Please try a different address.');
+                showToast('Location not found. Please try a different address.', 'error');
             }
         }
     }, function(error) {
         console.error('Geocoding error:', error);
-        alert('Error searching for location. Please try again.');
+        showToast('Error searching for location. Please try again.', 'error');
     });
 }

--- a/server.js
+++ b/server.js
@@ -40,6 +40,13 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(flash());
 
+//Adding a 1 Liner middleware to make flash messages available in all views
+app.use((req, res, next) => {
+  res.locals.messages = req.flash();
+  next();
+});
+
+
 //could use this for every view page / DRY. DON'T DELETE!  Will test when front end functionality is completed./ able to test a user requirment.
 // app.use((req, res, next) => {
 //   res.locals.user = req.user;

--- a/views/mapView.ejs
+++ b/views/mapView.ejs
@@ -27,10 +27,10 @@
           <h3>Submit an Alert</h3>
           <p>Click the Map or Use the Form Below to Submit an Alert</p>
 
-          <form id="alertForm">
+          <form id="alertForm" novalidate>
             <div class="form-group">
               <label for="incidentType">Incident Type</label>
-              <select id="incidentType" name="incidentType">
+              <select id="incidentType" name="incidentType" required>
                 <option value="">Select Type</option>
                 <option value="accessibility">Accessibility</option>
                 <option value="suspiciousActivity">Suspicious Activity</option>
@@ -45,7 +45,8 @@
                 type="text"
                 id="address"
                 name="address"
-                placeholder="Enter Address" />
+                placeholder="Enter Address"
+                required />
             </div>
 
             <div class="form-group">
@@ -53,7 +54,8 @@
               <textarea
                 id="description"
                 name="description"
-                placeholder="Enter Incident Details"></textarea>
+                placeholder="Enter Incident Details"
+                required></textarea>
             </div>
 
             <div class="checkbox-group">
@@ -77,7 +79,7 @@
     <!-- Pass server data to JavaScript -->
 <script>
   window.serverData = {
-        mapCenter: <%- JSON.stringify(locals.mapCenter) %>
+        mapCenter: <%- JSON.stringify(locals.mapCenter) %>,
         markers: <%- JSON.stringify(locals.markers) %> };
 </script>
      

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -26,6 +26,22 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <!-- Leaflet Control Geocoder JS -->
     <script src="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.js"></script>
+
+    <!-- Custom JS CDN & TOAST Logic -->
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <script src="/js/toast.js"></script>
+
+    <!-- If there’s at least one success, error on info message, this shows it on each ejs page w a diff color, catches errors in realtime display  -->
+     <script>
+      <% if (messages.success && messages.success.length > 0) { %>
+        showToast("<%= messages.success[0] %>", "success");
+      <% } else if (messages.error && messages.error.length > 0) { %>
+        showToast("<%= messages.error[0] %>", "error");
+      <% } else if (messages.info && messages.info.length > 0) { %>
+        showToast("<%= messages.info[0] %>", "info");
+      <% } %>
+    </script>
+
   </body>
 </html>
 

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -34,9 +34,10 @@
     <!-- If there’s at least one success, error on info message, this shows it on each ejs page w a diff color, catches errors in realtime display  -->
      <script>
       <% if (messages.success && messages.success.length > 0) { %>
-        showToast("<%= messages.success[0] %>", "success");
-      <% } else if (messages.error && messages.error.length > 0) { %>
-        showToast("<%= messages.error[0] %>", "error");
+        showToast("<%= messages.success[0].msg %>", "success");
+      <% } else if (messages.errors && messages.errors.length > 0) { %>
+      // grab the “msg” property from the first errors array element
+        showToast("<%= messages.errors[0].msg %>", "error");
       <% } else if (messages.info && messages.info.length > 0) { %>
         showToast("<%= messages.info[0] %>", "info");
       <% } %>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -11,6 +11,10 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <!-- Leaflet Control Geocoder CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.css" />
+  
+    <!-- Toastify CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
+
   </head>
   <body>
 

--- a/views/signin.ejs
+++ b/views/signin.ejs
@@ -18,7 +18,7 @@
       <section class="sign-intro">
         <h2 class="sign-account">Sign In to your Account <i class="fa-solid fa-address-card fa-fade fa-sm" style="color: #504f53;"></i></h2> 
       </section> 
-      <form class="sign-page-form" action="/signin" method="POST">
+      <form class="sign-page-form" action="/signin" method="POST" novalidate>
         <span class="sign-welcome">Welcome back!</span>
         <div class="mb-3 sign-page-div">
           <label for="email" class="form-label">Email:</label>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -22,11 +22,11 @@
                 <section class="sign-intro">
                   <h2 class="sign-account">Sign Up to Create Alerts <i class="fa-solid fa-bell fa-shake fa-sm" style="color: #e72222;"></i></h2>
                 </section> 
-                <form class="sign-page-form" action="/signup" method="POST">
+                <form class="sign-page-form" action="/signup" method="POST" novalidate >
                     <div class="mb-3 sign-page-div">
                       <span class="sign-welcome">Welcome!</span>
                       <label for="email" class="form-label">Email:</label>
-                      <input type="email" class="form-control" id="email" aria-describedby="emailHelp" name="email" placeholder="Enter email address" required>
+                      <input type="email" class="form-control" id="email" aria-describedby="emailHelp" name="email" placeholder="user@email.com" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$">
                     </div>
                     <div class="mb-3 sign-page-div">
                         <label for="firstName" class="form-label">First Name:</label>
@@ -38,7 +38,7 @@
                     </div>
                     <div class="mb-3 sign-page-div">
                       <label for="password" class="form-label">Password:</label>
-                      <input type="password" class="form-control" id="password" name="password" placeholder="Enter password" required>
+                      <input type="password" class="form-control" id="password" name="password" placeholder="At least 8 characters" required>
                     </div>
                     <div class="mb-3 sign-page-div">
                       <label for="confirmPassword" class="form-label">Confirm Password:</label>
@@ -46,7 +46,7 @@
                     </div>
                     <div class="mb-3 sign-page-div">
                       <label for="zipCode" class="form-label sign-zip-code">Zip Code:</label>
-                      <input type="text" class="form-control sign-zip-code" pattern="[0-9]{5}" title="Please enter a 5-digit zip code" id="zipCode" name="zipCode" placeholder="Enter zip code" required>
+                      <input type="text" class="form-control sign-zip-code" pattern="[0-9]{5}" title="Please enter a 5-digit zip code" id="zipCode" name="zipCode" placeholder="5-digit zip code" required>
                     </div>
                     <button class="sign-button" type="submit" class="btn btn-primary">Sign Up</button>
                     <p>Already have an account? <a class="sign-link" href="/signin">Sign In.</a></p>


### PR DESCRIPTION
**Related Issue(s):**
Closes #178

**Branch:** 178-integrate-toastifyjs

**What’s Included:**
- Integrated ToastifyJS across Sign-In, Sign-Up, and Map forms
- Replaced all native HTML5 validation pop-ups and alert() calls with styled toast messages
- Added public/js/toast.js to globally handle URL-based toasts and intercept form validation failures
- Updated views/partials/footer.ejs so that any req.flash messages render as Toastify toasts on every page
- Modified public/mapView(main).js to call showToast(...) instead of alert(...) for both form validation and server errors
- Adjusted views/signin.ejs, views/signup.ejs, and views/mapView.ejs to add novalidate on <form> and required attributes on inputs

**Notes for Reviewers:**
- Verify that Sign-In and Sign-Up pages no longer show native browser pop-ups, and instead show toast notifications on validation errors/success
- Confirm that the Map “Submit Alert” form uses showToast(…) for missing fields, geocoding failures, and successful submissions
- Make sure existing map pins still render correctly (if there’s any regression, it may require a separate frontend fix)
- No backend logic was touched, except adding 1 liner for middleware on server.js, only front-end files were updated. If anything breaks server-side, it should be unrelated to toast integration.

-  **May need to add a second fix ticket to add toast alerts and make sure they show up on feed.ejs and post.ejs pages, but rn signup/signin and map pages correctly display toast alerts**