### PR TITLE
fix(map): move Leaflet JS from footer to mapView.ejs

### DIFF
--- a/views/mapView.ejs
+++ b/views/mapView.ejs
@@ -83,7 +83,12 @@
         markers: <%- JSON.stringify(locals.markers) %> };
 </script>
      
-
+  <!-- Your main Map JavaScript file - moved here and out of header to load only on this map page -->
+    <script src="mapView(main).js"></script>
+  <!-- Leaflet JS -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <!-- Leaflet Control Geocoder JS -->
+    <script src="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.js"></script>
 
     <!-- Footer -->
     <%- include('partials/footer') -%>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -20,12 +20,6 @@
   <script
       src="https://kit.fontawesome.com/f8ec983be8.js"
       crossorigin="anonymous"></script>
-  <!-- Your main JavaScript file -->
-    <script src="mapView(main).js"></script>
-  <!-- Leaflet JS -->
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <!-- Leaflet Control Geocoder JS -->
-    <script src="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.js"></script>
 
     <!-- Custom JS CDN & TOAST Logic -->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>


### PR DESCRIPTION
**Related Issue(s):**
Closes #187 

**Branch:** 187-move-leaflettags-to-mapviewejs

**What’s Included:**
- This PR moves all Leaflet.js script tags from footer.ejs into mapView.ejs to ensure the map scripts only load on the map view page and reduce unnecessary JS on other pages. 
- The map still renders correctly after this change when tested in the browser.
