### PR TITLE
Fix: Removed margin from * element to fix header/footer

### DIFF
--- a/public/css/feed.css
+++ b/public/css/feed.css
@@ -339,7 +339,7 @@ svg {
     content: attr(data-three);
 }
 
-/* Layout spacing for view */
+/* Layout spacing for view class */
 .view {
     margin-bottom: 5px;
 }


### PR DESCRIPTION
Title: Fix: Removed margin from * element to fix header/footer

Related Issue(s): Closes #205 

Branch: 205-remove-feed-margin

What’s Included:
One line change to add margin: 0px to * element in public/css/feed.css file to fix formatting of both the header/footer

Notes for Reviewers:
N/A