### PR TITLE
fix: Fixed sticky footer on all pages by removing position property

### DIFF
--- a/public/css/headerFooter.css
+++ b/public/css/headerFooter.css
@@ -72,7 +72,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  position: sticky;
   box-sizing: border-box;
   bottom: 0;
   width: 100%;


### PR DESCRIPTION
Title: Fixed sticky footer on all pages by removing position property

Related Issue(s): Closes #209 

Branch: 209-remove-sticky-footer

What’s Included:
Fix: Fixed sticky footer on all pages by removing position property (position: sticky).

Notes for Reviewers:
Currently looking into overflow interaction happening on home page with footer and card section, will need to be fix for another ticket.