### PR TITLE
fix: changed alert to sightings and return to feed to return to sight…

### DIFF
--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -5,7 +5,7 @@
 <%- include('partials/header') -%>
 
   <div class="container">
-    <h1 class="center navy-blue">Post Sightings</h1>
+    <h1 class="center navy-blue">Sightings</h1>
 
     <h3 class="center black">View real-time incidents to help vulnerable communities</h3>
     <!-- Filter types stored in data attribute -->

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -24,7 +24,7 @@
   <nav class="nav-menu">
     <a href="/" class="<%= typeof currentPage !== 'undefined' && currentPage === 'home' ? 'active' : '' %>">Home</a>
     <a href="/map" class="<%= typeof currentPage !== 'undefined' && currentPage === 'map' ? 'active' : '' %>">Map</a>
-    <a href="/feed" class="<%= typeof currentPage !== 'undefined' && currentPage === 'alert' ? 'active' : '' %>">Alerts</a>
+    <a href="/feed" class="<%= typeof currentPage !== 'undefined' && currentPage === 'sightings' ? 'active' : '' %>">Sightings</a>
     <a href="/resources" class="<%= typeof currentPage !== 'undefined' && currentPage === 'resources' ? 'active' : '' %>">Resources</a>
 
     <% if (typeof user !== 'undefined' && user) { %>  

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -122,7 +122,7 @@
 
         <div class="mapFeedButton">
           <a href="/map"><i class="fas fa-map-marked-alt"></i> Return to Map</a>
-          <a href="/feed"><i class="fas fa-stream"></i> Return to Feed</a>
+          <a href="/feed"><i class="fas fa-stream"></i> Return to Sightings</a>
         </div>
       </div> 
       <div class="delete">


### PR DESCRIPTION
**Title:** updated navbar link name to be "sightings" instead of "Alerts"

**Related Issue(s):**
- Closes #200 


**Branch:** 200-update-feed-sightings

What’s Included
changed all occurrences of "Alert" and "feed" to Sightings
