### PR TITLE
fix: removing position property to fix footer on all pages

### DIFF
--- a/public/css/headerFooter.css
+++ b/public/css/headerFooter.css
@@ -75,7 +75,6 @@
   box-sizing: border-box;
   bottom: 0;
   width: 100%;
-  position: absolute;
 }
 
 .footer-left {


### PR DESCRIPTION
Title: fix: removing position property to fix footer on all pages

Related Issue(s): Closes #224 

Branch: 224-remove-absolute-positioning

What’s Included:
Removed position:absolute from headerFooter.css file in order to fix footer on all pages.

Notes for Reviewers:
N/A