### PR TITLE
fix: changed all references to alerts to sightings to match brand and cohesity across the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **About:** SafeRoute is a community-powered safety map designed for neighborhoods to come together and empower one another with knowledge and resources. It lets residents anonymously report sightings of broken streetlights, suspicious activity, dangerous infrastructure, and more.
 
-With a clean map view and accessible submission form, SafeRoute enables everyone— especially marginalized communities such as disabled folks, women, and elders— to move through their communities with confidence. SafeRoute is built for local awareness, fear reduction, and community solidarity through real-time, peer-sourced alerts.
+With a clean map view and accessible submission form, SafeRoute enables everyone— especially marginalized communities such as disabled folks, women, and elders— to move through their communities with confidence. SafeRoute is built for local awareness, fear reduction, and community solidarity through real-time, peer-sourced sightings.
 
 **Project Link:** [SafeRoute](https://safe-route-6iqv.onrender.com/)
 
@@ -12,10 +12,10 @@ With a clean map view and accessible submission form, SafeRoute enables everyone
 <img width="500" alt="saferoute-resources-page" src="https://github.com/user-attachments/assets/f571bc2f-3ffa-48a3-ad99-88be7f47fe77" />
 
 ## 🌟 Key Features:
-   - **Alert Reporting**
+   - **Safety Sightings**
        Report harassment, hazards, and accessibility barriers in real time to improve local safety.
    - **Interactive Map**
-       Explore alerts posted by neighbors directly on an easy-to-use interactive map.
+       Explore sightings posted by neighbors directly on an easy-to-use interactive map.
    - **Community Resources**
        Access safety tips, support helplines, and accessibility services tailored to your city.
 

--- a/public/mapView(main).js
+++ b/public/mapView(main).js
@@ -333,7 +333,7 @@ function performGeocode(query, originalInput) {
     }
   });
 
-  console.log('Searching alerts near:', originalInput);
+  console.log('Searching sightings near:', originalInput);
 
   geocoder.geocode(
     query,

--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -5,7 +5,7 @@
 <%- include('partials/header') -%>
 
   <div class="container">
-    <h1 class="center navy-blue">Sightings</h1>
+    <h1 class="center navy-blue">Local Sightings</h1>
 
     <h3 class="center black">View real-time sightings that improve accessibility and promote safer, walkable communities</h3>
     <!-- Filter types stored in data attribute -->

--- a/views/landing.ejs
+++ b/views/landing.ejs
@@ -23,12 +23,12 @@
   <!-- Features Section -->
   <section class="features">
     <div class="feature">
-      <h2>Alert Reporting</h2>
+      <h2>Real-Time Sightings</h2>
       <p>Report harassment, hazards, and accessibility barriers in real time to improve local safety.</p>
     </div>
     <div class="feature">
       <h2>Interactive Map</h2>
-      <p>Explore alerts posted by neighbors directly on an easy-to-use interactive map.</p>
+      <p>Explore sightings posted by neighbors directly on an easy-to-use interactive map.</p>
     </div>
     <div class="feature">
       <h2>Community Resources</h2>

--- a/views/mapView.ejs
+++ b/views/mapView.ejs
@@ -13,9 +13,9 @@
       <aside class="sidebar">
         <h2>Map View Page</h2>
 
-        <!-- View Nearby Alerts Section -->
+        <!-- View Nearby Sightings Section -->
         <section class="section">
-          <h3>View Nearby Alerts</h3>
+          <h3>View Nearby Sightings</h3>
           <p>No Sign-In Needed</p>
           <div class="form-group">
             <input
@@ -26,10 +26,10 @@
           <button class="submit-btn" onclick="searchAlerts()">Submit</button>
         </section>
 
-        <!-- Submit an Alert Section -->
+        <!-- Submit an Sighting/Alert Section -->
         <section class="section">
-          <h3>Submit an Alert</h3>
-          <p>Click the Map or Use the Form Below to Submit an Alert</p>
+          <h3>Report a Sighting</h3>
+          <p>Click the Map or Use the Form Below to Share a Community Sighting</p>
 
           <form id="alertForm" novalidate>
             <div class="form-group">
@@ -68,7 +68,7 @@
               <label for="uploadImage">Upload Image</label>
             </div>
 
-            <button type="submit" class="submit-btn">Submit Alert</button>
+            <button type="submit" class="submit-btn">Share Sighting</button>
           </form>
         </section>
       </aside>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -9,7 +9,7 @@
   <div class="footer-links">
     <a href="/">Home</a>
     <a href="/map">Map</a>
-    <a href="/feed">Alerts</a>
+    <a href="/feed">Sightings</a>
     <a href="/resources">Resources</a>
   </div>
 </footer>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -33,7 +33,7 @@
       <a href="/" class="<%= typeof currentPage !== 'undefined' && currentPage === 'home' ? 'active' : '' %>">Home</a>
       <a href="/map" class="<%= typeof currentPage !== 'undefined' && currentPage === 'map' ? 'active' : '' %>">Map</a>
       <a href="/feed"
-        class="<%= typeof currentPage !== 'undefined' && currentPage === 'alert' ? 'active' : '' %>">Alerts</a>
+        class="<%= typeof currentPage !== 'undefined' && currentPage === 'alert' ? 'active' : '' %>">Sightings</a>
       <a href="/resources"
         class="<%= typeof currentPage !== 'undefined' && currentPage === 'resources' ? 'active' : '' %>">Resources</a>
 

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -20,7 +20,7 @@
                     <% }) %>    
                 <% } %>
                 <section class="sign-intro">
-                  <h2 class="sign-account">Sign Up to Create Alerts <i class="fa-solid fa-bell fa-shake fa-sm" style="color: #e72222;"></i></h2>
+                  <h2 class="sign-account">Sign Up to Share Sightings <i class="fa-solid fa-bell fa-shake fa-sm" style="color: #e72222;"></i></h2>
                 </section> 
                 <form class="sign-page-form" action="/signup" method="POST" novalidate >
                     <div class="mb-3 sign-page-div">


### PR DESCRIPTION
**Related Issue(s):**
Closes #140

**Branch**: 230-update-footer-text

**What’s Included:**
Updated feed.ejs H1 from "Sightings" to "Local Sightings"
Adjusted H2 to avoid repeating "real-time"

Minor sitewide text changes to match new terminology:
- landing.ejs
- mapView.ejs
- signup.ejs
- partials/header.ejs
- partials/footer.ejs
- README.md
- public/mapView(main).js (if any visible string edits made, no logic break)

**Notes for Reviewers:**
- Confirm the new headings display correctly across screen sizes
- No logic or backend routes were changed — purely content/UI-level edits
- Please double-check that all references to "alerts" now use "sightings" for consistency